### PR TITLE
設定ファイル各記述を「payjp_app2」から「payjp_app」に変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>PayjpApp2</title>
+    <title>PayjpApp</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module PayjpApp2
+module PayjpApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: payjp_app2_production
+  channel_prefix: payjp_app_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,14 +19,14 @@ default: &default
 
 development:
   <<: *default
-  database: payjp_app2_development
+  database: payjp_app_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: payjp_app2_test
+  database: payjp_app_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -50,6 +50,6 @@ test:
 #
 production:
   <<: *default
-  database: payjp_app2_production
-  username: payjp_app2
-  password: <%= ENV['PAYJP_APP2_DATABASE_PASSWORD'] %>
+  database: payjp_app_production
+  username: payjp_app
+  password: <%= ENV['PAYJP_APP_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
アプリのディレクトリ名とリポジトリ名の変更に伴い、データベース名も統一することにした。
mysqldumpコマンドにて、データのバックアップをとり、上記の通り設定ファイル（特にdatabase.yml）をディレクトリ名に合わせて書き直したあと、再びmysqldumpコマンドでデータを移した。